### PR TITLE
Refactor Docker setup for single-stage build

### DIFF
--- a/backend/Dockerfile.test
+++ b/backend/Dockerfile.test
@@ -1,5 +1,0 @@
-FROM python:3.12.11-slim
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-CMD echo 'Docker build would work'

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: development  # If you want to add a multi-stage build later
+      # target: development  # Commented out - single-stage Dockerfile
     image: cookify-api:dev
     container_name: cookify_api_dev
     ports:


### PR DESCRIPTION
Remove the test Dockerfile and update the docker-compose configuration to support a single-stage build.